### PR TITLE
Build Docker image for solardata_exporter

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,22 +13,36 @@ jobs:
     strategy:
       matrix:
         arch: ['amd64', 'arm64']
+    env:
+      GOARCH: ${{ matrix.arch }}
     steps:
     - uses: actions/checkout@v4
+    - uses: docker/setup-qemu-action@v3
+    - uses: docker/setup-buildx-action@v3
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: '1.20'
 
     - name: Build
-      run: go build -v ./...
-      env:
-        GOARCH: ${{ matrix.arch }}
+      run: |
+        mkdir -p bin
+        go build -v -o bin/solardata_exporter .
 
     - name: Test
-      run: go test -v ./...
-      env:
-        GOARCH: ${{ matrix.arch }}
+      run: go test -v .
 
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+    - name: Build and push image
+      uses: docker/build-push-action@v3
+      with:
+        context: .
+        platforms: linux/${{ matrix.arch }}
+        push: true
+        tags: tzermias/solardata_exporter:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM debian:stable-slim
+
+ARG BIN_DIR=bin
+RUN apt-get update && \
+    apt-get install -y ca-certificates && \
+    apt-get clean all && \
+    ln -sf /dev/null /dev/log
+COPY $BIN_DIR/solardata_exporter /bin
+
+EXPOSE 9101
+USER nobody
+ENTRYPOINT [ "/bin/solardata_exporter" ]


### PR DESCRIPTION
Provide a basic build Github workflow that builds the artifact, creates
a Docker image and pushes it to Docker hub.
No Docker image version is handled yet.
