### PR TITLE
Define a User-Agent when performing requests.

### DIFF
--- a/pkg/exporter/exporter.go
+++ b/pkg/exporter/exporter.go
@@ -29,6 +29,9 @@ const (
 
 	// Prometheus namespace
 	namespace = "solar"
+
+	// User-Agent to use when performing requests
+	user_agent = "solardata_exporter/0.1 (https://github.com/tzermias/solardata_exporter)"
 )
 
 var (
@@ -132,6 +135,7 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 
 	// Fetch data from the URL and parse them
 	fp := gofeed.NewParser()
+	fp.UserAgent = user_agent
 	feed, err := fp.ParseURL(feed_url)
 	if err != nil {
 		log.Println("Could not fetch RSS data")


### PR DESCRIPTION
To avoid using `gofeed` default user-agent, this commit defines an
appropriate User-Agent to be used when performing requests.
