### PR TITLE
Update Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,11 @@ updates:
   directory: /
   schedule:
     interval: monthly
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: monthly
+- package-ecosystem: docker
+  directory: /
+  schedule:
+    interval: monthly


### PR DESCRIPTION
Configures Dependabot to check for Docker and Github action updates once
a month.
